### PR TITLE
add hook to TDisruptorServer that allows subclasses to handle when a connection is closed.

### DIFF
--- a/src/main/java/com/thinkaurelius/thrift/TDisruptorServer.java
+++ b/src/main/java/com/thinkaurelius/thrift/TDisruptorServer.java
@@ -527,8 +527,8 @@ public abstract class TDisruptorServer extends TNonblockingServer implements TDi
 
         private void cancelMessage(Message message)
         {
+            beforeClose(message);
             message.cancel();
-            onConnectionClose(message);
         }
 
         public void subscribe(TNonblockingTransport newClient)
@@ -550,7 +550,7 @@ public abstract class TDisruptorServer extends TNonblockingServer implements TDi
     /**
      * Allows derived classes to react when a connection is closed.
      */
-    protected void onConnectionClose(Message buffer)
+    protected void beforeClose(Message buffer)
     {
         //NOP by default
     }


### PR DESCRIPTION
Part of CASSANDRA-5719, we need to release the ClientState instance when a connection is closed. So add a method to TDisruptorThrift that can be overridden by THsHaDisruptorServer (in the cassandra 2.0 codebase).
