### PR TITLE
Cleanup selector's keys before closing the selector

### DIFF
--- a/src/main/java/com/thinkaurelius/thrift/TDisruptorServer.java
+++ b/src/main/java/com/thinkaurelius/thrift/TDisruptorServer.java
@@ -344,6 +344,9 @@ public abstract class TDisruptorServer extends TNonblockingServer implements TDi
             {
                 while (!isStopped())
                     select();
+                
+                for (SelectionKey key: selector.keys())
+                    cleanupSelectionKey(key);
 
                 selector.close();
             }
@@ -415,7 +418,10 @@ public abstract class TDisruptorServer extends TNonblockingServer implements TDi
             Message message = (Message) key.attachment();
 
             if (message != null)
+            {
+                beforeClose(message);
                 message.close();
+            }
 
             // cancel the selection key
             key.cancel();


### PR DESCRIPTION
During https://issues.apache.org/jira/browse/CASSANDRA-6546 testing we've discovered that Cassandra's `THsHaDisruptorServer` doesn't clean the connections.  Because its `beforeClose` isn't called during the `stop` operation.
