### PR TITLE
Move junit dependency to the test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.8.1</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This leaks up the cassandra dependency hierarchy to many web services.  It would be much appreciated to not have to exclude junit manually in those apps.